### PR TITLE
Add support for MCPC+ servers

### DIFF
--- a/src/main/java/de/dustplanet/silkspawners/SilkSpawners.java
+++ b/src/main/java/de/dustplanet/silkspawners/SilkSpawners.java
@@ -240,7 +240,11 @@ public class SilkSpawners extends JavaPlugin {
 
 				// Get the modID field, see
 				// https://github.com/Bukkit/CraftBukkit/blob/master/src/main/java/net/minecraft/server/TileEntityMobSpawner.java#L11
-				su.mobIDField = TileEntityMobSpawner.class.getDeclaredField("mobName");
+				try {
+					su.mobIDField = TileEntityMobSpawner.class.getDeclaredField("mobName"); // CB name
+				} catch (NoSuchFieldException ex) {
+					su.mobIDField = TileEntityMobSpawner.class.getDeclaredField("d"); // obfuscated name
+				}
 				su.mobIDField.setAccessible(true);
 			}
 			catch (Exception e) {

--- a/src/main/java/de/dustplanet/util/ErrorLogger.java
+++ b/src/main/java/de/dustplanet/util/ErrorLogger.java
@@ -162,7 +162,11 @@ public class ErrorLogger extends PluginLogger {
 					generateErrorLog(throwable);
 				}
 			});
-			mcLogger = MinecraftServer.class.getDeclaredField("log");
+			try {
+				mcLogger = MinecraftServer.class.getDeclaredField("log"); // CB name
+			} catch (NoSuchFieldException ex) {
+				mcLogger = MinecraftServer.class.getDeclaredField("a"); // obfuscated name
+			}
 			mcLogger.setAccessible(true);
 			craftbukkitServer = CraftServer.class.getDeclaredField("console");
 			craftbukkitServer.setAccessible(true);


### PR DESCRIPTION
Allows running SilkSpawners in an obfuscated environment, e.g., MCPC+:

http://www.mcportcentral.co.za/index.php?topic=4657.0

Also added EntityType to the verbose output since it was useful for debugging an issue (https://github.com/MinecraftPortCentral/MCPC-Plus/issues/16 if you're curious)

Cheers
