### PR TITLE
Fix a major dupelication glitch while having a SilkSpawner in your hand,...

### DIFF
--- a/src/main/java/de/dustplanet/silkspawners/listeners/SilkSpawnersBlockListener.java
+++ b/src/main/java/de/dustplanet/silkspawners/listeners/SilkSpawnersBlockListener.java
@@ -33,7 +33,7 @@ public class SilkSpawnersBlockListener implements Listener {
 	su = util;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
 	if (event.isCancelled()) {
 	    return;


### PR DESCRIPTION
... and breaking plants. Dupelicates items, and if McMMO is installed, infinite levels are included

To xGhOsTkiLLeRx, EventPriority.MONITOR is fired after the event is executed and should not be used to actually modify the outcome of an event.
