### PR TITLE
chore: add Let's Encrypt cert to CircleCI env

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,10 +5,10 @@ dependencies:
   pre:
     - java -version
     - mvn -version
-    - mvn -s conf/settings.xml clean install
-  override:
     - wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
     - sudo keytool -trustcacerts -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass changeit -noprompt -importcert -file lets-encrypt-x3-cross-signed.pem
+    - mvn -s conf/settings.xml clean install
+  override:
     - mvn -s conf/settings.xml dependency:resolve
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,12 @@ machine:
     version: oraclejdk8
 dependencies:
   pre:
+    - java -version
     - mvn -version
     - mvn -s conf/settings.xml clean install
   override:
+    - wget https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
+    - sudo keytool -trustcacerts -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass changeit -noprompt -importcert -file lets-encrypt-x3-cross-signed.pem
     - mvn -s conf/settings.xml dependency:resolve
 test:
   override:


### PR DESCRIPTION
due to outdated JDK and no fix since September: https://github.com/circleci/image-builder/pull/99