### PR TITLE
Add config option to disable blocking right click on spawner with egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ ignoreCheckNumbers: false
 # Disable left click to change spawners, spawns a mob instead. Still blocks Vanilla right click behavior.
 disableChangeTypeWithEgg: false
 
+# Disable right click to change spawners, spawns mob instead. Still blocks left click behavior. (unless disableChangeTypeWithEgg is true)
+disableChangeTypeWithEggRightClick: false
+
 # Should instead of spawning a mob a MonsterSpawner be placed? (Uses consumeEgg value, too)
 spawnEggToSpawner: false
 

--- a/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/configs/Config.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/configs/Config.java
@@ -78,7 +78,9 @@ public class Config extends AbstractConfiguration {
         config.addDefault("ignoreCheckNumbers", false);
         config.addComment("ignoreCheckNumbers", "", "# Should numbers be ignored (on eggs) and allow every number value?");
         config.addDefault("disableChangeTypeWithEgg", false);
-        config.addComment("disableChangeTypeWithEgg", "", "# Disable left click to change spawners, spawns a mob instead. Still blocks Vanilla right click behavior.");
+        config.addComment("disableChangeTypeWithEgg", "", "# Disable left click to change spawners, spawns a mob instead. Still blocks Vanilla right click behavior.  (unless disableChangeTypeWithEggRightClick is true)");
+        config.addDefault("disableChangeTypeWithEggRightClick", false);
+        config.addComment("disableChangeTypeWithEggRightClick", "", "# Disable right click to change spawners, spawns mob instead. Still blocks left click behavior. (unless disableChangeTypeWithEgg is true)");
         config.addDefault("spawnEggToSpawner", false);
         config.addComment("spawnEggToSpawner", "", "# Should instead of spawning a mob a MonsterSpawner be placed? (Uses consumeEgg value, too)");
         config.addDefault("spawnEggOverride", false);

--- a/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/listeners/SilkSpawnersPlayerListener.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/listeners/SilkSpawnersPlayerListener.java
@@ -90,6 +90,8 @@ public class SilkSpawnersPlayerListener implements Listener {
 
                 if (action != Action.RIGHT_CLICK_BLOCK && plugin.config.getBoolean("disableChangeTypeWithEgg", false)) {
                     return;
+                } else if(action == Action.RIGHT_CLICK_BLOCK && plugin.config.getBoolean("disableChangeTypeWithEggRightClick")) {
+                    return;
                 }
 
                 // WorldGuard region protection

--- a/modules/SilkSpawners/src/main/resources/config.yml
+++ b/modules/SilkSpawners/src/main/resources/config.yml
@@ -93,8 +93,11 @@ enableCreatureDefault: true
 # Should numbers be ignored (on eggs) and allow every number value?
 ignoreCheckNumbers: false
  
-# Disable left click to change spawners, spawns a mob instead. Still blocks Vanilla right click behavior.
+# Disable left click to change spawners, spawns a mob instead. Still blocks Vanilla right click behavior.  (unless disableChangeTypeWithEggRightClick is true)
 disableChangeTypeWithEgg: false
+
+# Disable right click to change spawners, spawns mob instead. Still blocks left click behavior. (unless disableChangeTypeWithEgg is true)
+disableChangeTypeWithEggRightClick: false
  
 # Should instead of spawning a mob a MonsterSpawner be placed? (Uses consumeEgg value, too)
 spawnEggToSpawner: false


### PR DESCRIPTION
Although default minecraft changes spawners by right clicking eggs, this can be disabled, and so SilkSpawners should not force you to use their right-clicking spawner changing feature.