### PR TITLE
Pass entity to SilkSpawnersSpawnerExplodeEvent

### DIFF
--- a/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/events/SilkSpawnersSpawnerExplodeEvent.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/events/SilkSpawnersSpawnerExplodeEvent.java
@@ -4,6 +4,7 @@ import javax.annotation.Nullable;
 
 import org.bukkit.block.Block;
 import org.bukkit.block.CreatureSpawner;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -39,6 +40,11 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
     private final Player player;
 
     /**
+     * Entity that caused the explosion
+     */
+    private final Entity entity;
+
+    /**
      * new Entity.
      */
     private String entityID;
@@ -71,7 +77,8 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
      * @param entityID new entity ID
      * @param dropChance the current dropChance
      */
-    public SilkSpawnersSpawnerExplodeEvent(@Nullable final Player player, final Block block, final String entityID, final int dropChance) {
+    public SilkSpawnersSpawnerExplodeEvent(Entity entity, @Nullable final Player player, final Block block, final String entityID, final int dropChance) {
+        this.entity = entity;
         this.player = player;
         this.block = block;
         this.dropChance = dropChance;
@@ -117,6 +124,14 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
      */
     public void setAllCancelled(final boolean allCancel) {
         this.allCancelled = allCancel;
+    }
+
+    /**
+     * Returns entity that caused the explosion
+     * @return Entity that caused the explosion
+     */
+    public Entity getEntity() {
+        return entity;
     }
 
     /**

--- a/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/events/SilkSpawnersSpawnerExplodeEvent.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/events/SilkSpawnersSpawnerExplodeEvent.java
@@ -40,7 +40,7 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
     private final Player player;
 
     /**
-     * Entity that caused the explosion
+     * Entity that caused the explosion.
      */
     @Nullable
     private final Entity entity;
@@ -93,11 +93,13 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
     /**
      * Constructor of the event.
      *
+     * @deprecated Use {@link SilkSpawnersSpawnerExplodeEvent#SilkSpawnersSpawnerExplodeEvent(Entity, Player, Block, String int)} instead.
      * @param player who issues the event, can be null
      * @param block is allowed to be null
      * @param entityID new entity ID
      * @param dropChance the current dropChance
      */
+    @Deprecated
     public SilkSpawnersSpawnerExplodeEvent(@Nullable final Player player, final Block block, final String entityID, final int dropChance) {
         this(null, player, block, entityID, dropChance);
     }
@@ -141,8 +143,8 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
     }
 
     /**
-     * Returns entity that caused the explosion
-     * @return Entity that caused the explosion
+     * Returns the entity that caused the explosion.
+     * @return the entity that caused the explosion
      */
     @Nullable
     public Entity getEntity() {

--- a/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/events/SilkSpawnersSpawnerExplodeEvent.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/events/SilkSpawnersSpawnerExplodeEvent.java
@@ -42,6 +42,7 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
     /**
      * Entity that caused the explosion
      */
+    @Nullable
     private final Entity entity;
 
     /**
@@ -72,12 +73,13 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
     /**
      * Constructor of the event.
      *
+     * @param entity that caused the explosion
      * @param player who issues the event, can be null
      * @param block is allowed to be null
      * @param entityID new entity ID
      * @param dropChance the current dropChance
      */
-    public SilkSpawnersSpawnerExplodeEvent(Entity entity, @Nullable final Player player, final Block block, final String entityID, final int dropChance) {
+    public SilkSpawnersSpawnerExplodeEvent(@Nullable Entity entity, @Nullable final Player player, final Block block, final String entityID, final int dropChance) {
         this.entity = entity;
         this.player = player;
         this.block = block;
@@ -86,6 +88,18 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
             this.spawner = (CreatureSpawner) block.getState();
         }
         this.entityID = entityID;
+    }
+
+    /**
+     * Constructor of the event.
+     *
+     * @param player who issues the event, can be null
+     * @param block is allowed to be null
+     * @param entityID new entity ID
+     * @param dropChance the current dropChance
+     */
+    public SilkSpawnersSpawnerExplodeEvent(@Nullable final Player player, final Block block, final String entityID, final int dropChance) {
+        this(null, player, block, entityID, dropChance);
     }
 
     /**
@@ -130,6 +144,7 @@ public class SilkSpawnersSpawnerExplodeEvent extends Event implements Cancellabl
      * Returns entity that caused the explosion
      * @return Entity that caused the explosion
      */
+    @Nullable
     public Entity getEntity() {
         return entity;
     }

--- a/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/listeners/SilkSpawnersEntityListener.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/silkspawners/listeners/SilkSpawnersEntityListener.java
@@ -79,7 +79,7 @@ public class SilkSpawnersEntityListener implements Listener {
                     dropChance = plugin.config.getInt("explosionDropChance", 100);
                 }
                 plugin.getLogger().log(Level.FINE, "Current drop chance is {0}", dropChance);
-                final SilkSpawnersSpawnerExplodeEvent explodeEvent = new SilkSpawnersSpawnerExplodeEvent(sourcePlayer, block, entityID,
+                final SilkSpawnersSpawnerExplodeEvent explodeEvent = new SilkSpawnersSpawnerExplodeEvent(entity, sourcePlayer, block, entityID,
                         dropChance);
                 plugin.getServer().getPluginManager().callEvent(explodeEvent);
                 if (explodeEvent.isAllCancelled()) {


### PR DESCRIPTION
Passing the entity that caused the explosion alongside `entityID` to make working with event easier. Allows you to modify event based on the actual entity that allows more flexibility when working with the API.

I haven't looked much into this but it might be better for this event to extend Bukkit's `EntityEvent`. 
This change might also break plugins which instantiate `SilkSpawnersSpawnerExplodeEvent`.