### PR TITLE
feat: filter entities in /spawner list by permission

### DIFF
--- a/modules/SilkSpawners/src/main/java/de/dustplanet/util/SilkUtil.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/util/SilkUtil.java
@@ -654,9 +654,13 @@ public class SilkUtil {
     public void showAllCreatures(final CommandSender sender) {
         // For each entry in the list
         final StringBuilder builder = new StringBuilder();
-        for (String displayName : displayNameToMobID.keySet()) {
+        for (Entry<String, String> entityType : displayNameToMobID.entrySet()) {
+            String displayName = entityType.getKey();
+            String entityId = entityType.getValue();
             displayName = displayName.replace(" ", "");
-            builder.append(displayName + ", ");
+            if (hasPermission(sender, "silkspawners.changetype.", entityId)) {
+                builder.append(displayName + ", ");
+            }
         }
         // Strip last comma out
         String message = builder.toString();


### PR DESCRIPTION
Currently, /spawner list displays ALL entities, regardless of whether the player actually has permission to use them or not. I believe it's more intuitive to include only the ones accessible by the command sender. 

In this PR, it filters by `silkspawners.changetype.<entity id>`, though it may be desired to have a separate node for that, for example `silkspawners.list.<entity id>`.