### PR TITLE
feat: allow Mimic custom items in allowedTools

### DIFF
--- a/modules/SilkSpawners/pom.xml
+++ b/modules/SilkSpawners/pom.xml
@@ -103,6 +103,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>ru.endlesscode.mimic</groupId>
+      <artifactId>mimic-bukkit-api</artifactId>
+      <version>0.8.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.bstats</groupId>
       <artifactId>bstats-bukkit</artifactId>
       <version>3.0.2</version>

--- a/modules/SilkSpawners/src/main/java/de/dustplanet/util/SilkUtil.java
+++ b/modules/SilkSpawners/src/main/java/de/dustplanet/util/SilkUtil.java
@@ -47,6 +47,7 @@ import de.dustplanet.silkspawners.compat.api.NMSProvider;
 import lombok.Getter;
 import lombok.Setter;
 import me.confuser.barapi.BarAPI;
+import ru.endlesscode.mimic.Mimic;
 
 /**
  * This is the util class where all the magic happens.
@@ -91,6 +92,11 @@ public class SilkUtil {
     private WorldGuardPlugin wg;
 
     /**
+     * Mimic instance, may be null
+     */
+    private Mimic mimic;
+
+    /**
      * BarAPI usage toggle.
      */
     @Getter
@@ -127,6 +133,7 @@ public class SilkUtil {
         }
 
         getWorldGuard();
+        getMimic();
         final boolean nmsProviderFound = setupNMSProvider();
 
         if (nmsProviderFound) {
@@ -816,6 +823,10 @@ public class SilkUtil {
                 toolAllowed = true;
                 break;
             }
+            if (mimic != null && mimic.getItemsRegistry().isSameItem(tool, allowedTool)) {
+                toolAllowed = true;
+                break;
+            }
         }
         if (!toolAllowed) {
             plugin.getLogger().log(Level.FINE, "Tool not allowed: {0}", tool.getType());
@@ -887,6 +898,20 @@ public class SilkUtil {
         }
         plugin.getLogger().info("WorldGuard was found and support is enabled");
         wg = (WorldGuardPlugin) worldGuard;
+    }
+
+    private void getMimic() {
+        if (!plugin.getConfig().getBoolean("useMimic", true)) {
+            plugin.getLogger().info("Mimic support is disabled due to config setting");
+            return;
+        }
+        final Plugin mimicPlugin = plugin.getServer().getPluginManager().getPlugin("Mimic");
+        if (mimicPlugin == null) {
+            plugin.getLogger().info("Mimic was not found and support is disabled");
+            return;
+        }
+        mimic = Mimic.getInstance();
+        plugin.getLogger().info("Mimic was found and support is enabled");
     }
 
     /**

--- a/modules/SilkSpawners/src/main/resources/config.yml
+++ b/modules/SilkSpawners/src/main/resources/config.yml
@@ -9,6 +9,9 @@ permissionExplode: false
 # Should be checked for WorldGuard build ability to change spawners
 useWorldGuard: true
 
+useMimic: true
+# Allows you to use Mimic item IDs in allowedTools
+
 # Percentage of dropping a spawner block when TNT or creepers explode
 explosionDropChance: 30
 

--- a/modules/SilkSpawners/src/main/resources/plugin.yml
+++ b/modules/SilkSpawners/src/main/resources/plugin.yml
@@ -50,5 +50,5 @@ permissions:
   silkspawners.help:
     description: Allows you to see the help menu
     default: true
-softdepend: [WorldGuard, BarAPI, Factions]
+softdepend: [WorldGuard, BarAPI, Factions, Mimic]
 loadbefore: [MergedSpawner, ShopGUIPlus]


### PR DESCRIPTION
[Mimic](https://github.com/EndlessCodeGroup/Mimic) is a plug-in that (among others) provides an API for custom item plug-ins to register their custom items, as well as an API for other plug-ins to interact with these registered custom items, without the need to know which plug-in defined the custom item.

This merge request uses the Mimic API to allow Mimic custom items to be used in the `allowedTools` in the `config.yml`.